### PR TITLE
Promote local v4.8.28 metadata and safe auto-patch workflow

### DIFF
--- a/.github/workflows/openai-auto-patch-pr.yml
+++ b/.github/workflows/openai-auto-patch-pr.yml
@@ -1,0 +1,96 @@
+name: OpenAI Auto Patch PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      brief_path:
+        description: "Brief file to send to OpenAI"
+        required: false
+        default: "bridge/latest-brief.md"
+      source_mode:
+        description: "Use github or local source context"
+        required: false
+        default: "github"
+        type: choice
+        options:
+          - github
+          - local
+      model:
+        description: "OpenAI model"
+        required: false
+        default: "gpt-5-codex"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: openai-auto-patch-pr
+  cancel-in-progress: false
+
+jobs:
+  generate-patch-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Generate OpenAI patch
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ inputs.model }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPO_FULL_NAME: ${{ github.repository }}
+          GITHUB_REPO_BRANCH: ${{ github.ref_name }}
+          PONGDANG_SOURCE_MODE: ${{ inputs.source_mode }}
+        run: |
+          node ./bridge/generate-patch.mjs --brief "${{ inputs.brief_path }}" --source-mode "${{ inputs.source_mode }}" --model "${{ inputs.model }}"
+
+      - name: Validate generated patch
+        run: |
+          node --check patches/latest.generated.patch.js
+          node bridge/validate-structure.mjs
+          node bridge/diagnose-stability.mjs
+
+      - name: Detect changes
+        id: diff
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ github.token }}
+          branch: auto/openai-patch-${{ github.run_id }}
+          delete-branch: true
+          title: "OpenAI auto patch"
+          commit-message: "Generate OpenAI auto patch"
+          body: |
+            ## Summary
+
+            - Generated a patch using `bridge/generate-patch.mjs`.
+            - Validation passed before PR creation.
+
+            ## Safety
+
+            This workflow does not push directly to `main`.
+            Please review the generated patch before merging.
+
+      - name: No changes
+        if: steps.diff.outputs.has_changes != 'true'
+        run: echo "No patch changes were generated."

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+.env.local
+patches/history/
+node_modules/
+*.log

--- a/GITHUB_AUTO_PATCH_GUIDE.md
+++ b/GITHUB_AUTO_PATCH_GUIDE.md
@@ -1,0 +1,39 @@
+# GitHub Actions 자동 패치 PR 가이드
+
+## 가장 안정적인 방식
+
+이 프로젝트는 OpenAI가 만든 패치를 `main`에 바로 넣지 않습니다.
+
+안정적인 흐름은 다음과 같습니다.
+
+1. GitHub Actions를 수동 실행한다.
+2. OpenAI Responses API가 패치를 생성한다.
+3. 구조/문법/안정성 검사를 통과해야 한다.
+4. 통과하면 자동으로 새 브랜치와 Pull Request를 만든다.
+5. 사람이 PR을 확인한 뒤 merge한다.
+
+## 필요한 GitHub Secret
+
+GitHub 저장소에서 아래 Secret을 추가합니다.
+
+`Settings` -> `Secrets and variables` -> `Actions` -> `New repository secret`
+
+필수 Secret:
+
+```text
+OPENAI_API_KEY
+```
+
+## 실행 방법
+
+1. GitHub 저장소로 이동한다.
+2. `Actions` 탭을 연다.
+3. `OpenAI Auto Patch PR` 워크플로를 선택한다.
+4. `Run workflow`를 누른다.
+5. 완료 후 `Pull requests` 탭에서 자동 생성된 PR을 확인한다.
+
+## 안전 장치
+
+- `main`에 직접 push하지 않음.
+- 검증 실패 시 PR 생성 안 함.
+- PR을 merge하기 전 사람이 변경 내용을 볼 수 있음.

--- a/OPENAI_CONNECT_GUIDE.md
+++ b/OPENAI_CONNECT_GUIDE.md
@@ -1,0 +1,31 @@
+# ChatGPT/OpenAI 연결 가이드
+
+## 현재 연결 방식
+
+이 프로젝트는 ChatGPT 웹사이트에 직접 붙는 방식이 아니라, OpenAI Responses API로 패치를 생성하는 방식입니다.
+
+연결 스크립트:
+
+```powershell
+node .\bridge\generate-patch.mjs --source-mode local
+```
+
+## API 키 설정
+
+로컬에서는 `.env` 파일에 아래 값을 넣습니다.
+
+```text
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-5-codex
+PONGDANG_SOURCE_MODE=local
+```
+
+GitHub Actions에서는 저장소 Secret으로 `OPENAI_API_KEY`를 넣습니다.
+
+## 검증
+
+```powershell
+node --check patches\latest.generated.patch.js
+node bridge\validate-structure.mjs
+node bridge\diagnose-stability.mjs
+```

--- a/bridge/diagnose-stability.mjs
+++ b/bridge/diagnose-stability.mjs
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.cwd();
+
+async function read(relPath) {
+  return fs.readFile(path.join(rootDir, relPath), "utf8");
+}
+
+function collect(regex, text) {
+  const safeRegex = regex.global ? regex : new RegExp(regex.source, `${regex.flags}g`);
+  return Array.from(text.matchAll(safeRegex), (match) => match[1]);
+}
+
+async function main() {
+  const [appHtml, patchText, manifestText, projectManifestText] = await Promise.all([
+    read("app_assets/index.html"),
+    read("patches/latest.generated.patch.js"),
+    read("manifest.json"),
+    read("project-manifest.json")
+  ]);
+
+  const manifest = JSON.parse(manifestText);
+  const projectManifest = JSON.parse(projectManifestText);
+  const patchVersion = collect(/version:\s*"([^"]+)"/, patchText)[0] || "";
+  const issues = [];
+
+  if (!patchVersion) issues.push("Patch version not found.");
+  if (manifest.version !== patchVersion) issues.push(`manifest version ${manifest.version} does not match patch ${patchVersion}`);
+  if (projectManifest.version !== patchVersion) issues.push(`project manifest version ${projectManifest.version} does not match patch ${patchVersion}`);
+  if (!appHtml.includes("fishLayer")) issues.push("fishLayer missing from app html");
+  if (!appHtml.includes("sheetLayer")) issues.push("sheetLayer missing from app html");
+  if (!appHtml.includes("modalLayer")) issues.push("modalLayer missing from app html");
+  if (patchText.includes("back.png") || patchText.includes('view: "back"')) issues.push("Forbidden back view reference found");
+
+  const report = { ok: issues.length === 0, patchVersion, issues, generatedAt: new Date().toISOString() };
+  await fs.mkdir(path.join(rootDir, "docs"), { recursive: true });
+  await fs.writeFile(path.join(rootDir, "docs/stability-diagnostics-latest.json"), JSON.stringify(report, null, 2) + "\n", "utf8");
+
+  if (issues.length) {
+    console.error(`Stability diagnostics found errors for ${patchVersion || "unknown"}.`);
+    for (const issue of issues) console.error(`[error] ${issue}`);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(`Stability diagnostics passed for ${patchVersion}.\n`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/bridge/generate-patch.mjs
+++ b/bridge/generate-patch.mjs
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.cwd();
+const bridgeDir = path.join(rootDir, "bridge");
+const promptsDir = path.join(rootDir, "prompts");
+const targetPatchPath = path.join(rootDir, "patches", "latest.generated.patch.js");
+
+async function readText(filePath) {
+  return fs.readFile(filePath, "utf8");
+}
+
+async function loadDotEnv() {
+  try {
+    const source = await readText(path.join(rootDir, ".env"));
+    for (const line of source.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const index = trimmed.indexOf("=");
+      if (index <= 0) continue;
+      const key = trimmed.slice(0, index).trim();
+      let value = trimmed.slice(index + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) value = value.slice(1, -1);
+      if (key && !process.env[key]) process.env[key] = value;
+    }
+  } catch {
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    briefPath: path.join(bridgeDir, "latest-brief.md"),
+    dryRun: false,
+    model: process.env.OPENAI_MODEL || "gpt-5-codex",
+    sourceMode: process.env.PONGDANG_SOURCE_MODE || "github"
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--dry-run") args.dryRun = true;
+    if (argv[i] === "--brief" && argv[i + 1]) args.briefPath = path.resolve(rootDir, argv[++i]);
+    if (argv[i] === "--model" && argv[i + 1]) args.model = argv[++i];
+    if (argv[i] === "--source-mode" && argv[i + 1]) args.sourceMode = argv[++i];
+  }
+  return args;
+}
+
+async function fetchGitHubTextFile(filePath) {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO_FULL_NAME || "tantarus71-ctrl/pongdang-v5-web";
+  const branch = process.env.GITHUB_REPO_BRANCH || "main";
+  if (!token) throw new Error("GITHUB_TOKEN is not set.");
+  const url = `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${encodeURIComponent(branch)}`;
+  const response = await fetch(url, { headers: { Accept: "application/vnd.github+json", Authorization: `Bearer ${token}` } });
+  if (!response.ok) throw new Error(`GitHub fetch failed for ${filePath}: ${response.status} ${await response.text()}`);
+  const json = await response.json();
+  return Buffer.from(json.content, "base64").toString("utf8");
+}
+
+async function loadSources(args) {
+  if (args.sourceMode === "local") {
+    return {
+      baseApp: await readText(path.join(rootDir, "app_assets", "index.html")),
+      currentPatch: await readText(targetPatchPath).catch(() => ""),
+      manifest: await readText(path.join(rootDir, "project-manifest.json")).catch(() => "")
+    };
+  }
+  return {
+    baseApp: await fetchGitHubTextFile("app_assets/index.html"),
+    currentPatch: await fetchGitHubTextFile("patches/latest.generated.patch.js").catch(() => ""),
+    manifest: await fetchGitHubTextFile("project-manifest.json").catch(() => "")
+  };
+}
+
+function extractOutputText(json) {
+  if (typeof json.output_text === "string" && json.output_text.trim()) return json.output_text.trim();
+  const chunks = [];
+  for (const item of json.output || []) for (const content of item.content || []) if (content.type === "output_text" && content.text) chunks.push(content.text);
+  return chunks.join("\n").trim();
+}
+
+function stripCodeFence(text) {
+  return text.replace(/^```(?:javascript|js)?\s*/i, "").replace(/\s*```$/, "").trim();
+}
+
+function assertPatchLooksSafe(source) {
+  if (!source.includes("window.PONDANG_AUTO_PATCH")) throw new Error("Generated patch is missing window.PONDANG_AUTO_PATCH.");
+  if (!source.includes("apply()")) throw new Error("Generated patch is missing apply().");
+}
+
+async function main() {
+  await loadDotEnv();
+  const args = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY is not set.");
+  if (apiKey.includes("여기에_") || /[^\x20-\x7E]/.test(apiKey)) throw new Error("OPENAI_API_KEY is still a placeholder.");
+
+  const [systemTemplate, userTemplate, brief, sources] = await Promise.all([
+    readText(path.join(promptsDir, "patch-system.md")),
+    readText(path.join(promptsDir, "patch-user-template.md")),
+    readText(args.briefPath),
+    loadSources(args)
+  ]);
+
+  const projectContext = [
+    "Stable runtime entry: app_assets/index.html",
+    "Auto patch target: patches/latest.generated.patch.js",
+    "Manifest snapshot:",
+    sources.manifest.trim() || "(manifest unavailable)"
+  ].join("\n");
+
+  const userPrompt = userTemplate
+    .replace("{{PROJECT_CONTEXT}}", projectContext)
+    .replace("{{USER_BRIEF}}", brief.trim())
+    .replace("{{CURRENT_PATCH}}", sources.currentPatch.trim())
+    .replace("{{BASE_APP_SNIPPET}}", sources.baseApp.slice(-18000).trim());
+
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ model: args.model, input: [{ role: "system", content: [{ type: "input_text", text: systemTemplate }] }, { role: "user", content: [{ type: "input_text", text: userPrompt }] }] })
+  });
+  if (!response.ok) throw new Error(`Responses API request failed: ${response.status} ${await response.text()}`);
+
+  const patchSource = stripCodeFence(extractOutputText(await response.json()));
+  assertPatchLooksSafe(patchSource);
+  if (args.dryRun) process.stdout.write(patchSource);
+  else {
+    await fs.mkdir(path.dirname(targetPatchPath), { recursive: true });
+    await fs.writeFile(targetPatchPath, patchSource + "\n", "utf8");
+    process.stdout.write(`Updated patch: ${targetPatchPath}\n`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/bridge/validate-structure.mjs
+++ b/bridge/validate-structure.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.cwd();
+const requiredFiles = [
+  "index.html",
+  "manifest.json",
+  "project-manifest.json",
+  "app_assets/index.html",
+  "patches/latest.generated.patch.js",
+  "bridge/generate-patch.mjs"
+];
+
+async function read(relPath) {
+  return fs.readFile(path.join(rootDir, relPath), "utf8");
+}
+
+async function exists(relPath) {
+  try {
+    await fs.access(path.join(rootDir, relPath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function main() {
+  for (const file of requiredFiles) {
+    if (!(await exists(file))) fail(`Missing required file: ${file}`);
+  }
+
+  const [manifestText, projectManifestText, appHtml, rootHtml, patchText] = await Promise.all([
+    read("manifest.json"),
+    read("project-manifest.json"),
+    read("app_assets/index.html"),
+    read("index.html"),
+    read("patches/latest.generated.patch.js")
+  ]);
+
+  const manifest = JSON.parse(manifestText);
+  const projectManifest = JSON.parse(projectManifestText);
+
+  if (manifest.entrypoints?.app !== "app_assets/index.html") fail("manifest app entrypoint must be app_assets/index.html");
+  if (projectManifest.html !== "app_assets/index.html") fail("project-manifest html must be app_assets/index.html");
+  if (!appHtml.includes("../patches/latest.generated.patch.js")) fail("app must load latest generated patch");
+  if (!patchText.includes("window.PONDANG_AUTO_PATCH")) fail("patch must expose window.PONDANG_AUTO_PATCH");
+  if (!rootHtml.includes("./app_assets/index.html")) fail("root index must redirect to ./app_assets/index.html");
+
+  process.stdout.write("Structure validation passed.\n");
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});

--- a/index.html
+++ b/index.html
@@ -1,2 +1,13 @@
 <!doctype html>
-<html lang="ko"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><title>퐁당4 GitHub 기준본 연결 안내</title><style>body{margin:0;font-family:system-ui,-apple-system,'Noto Sans KR',sans-serif;background:#07131f;color:#eef6ff;display:grid;place-items:center;min-height:100vh;padding:24px;box-sizing:border-box}.card{max-width:720px;background:#102436;border:1px solid rgba(255,255,255,.14);border-radius:24px;padding:24px;box-shadow:0 24px 60px rgba(0,0,0,.25)}h1{margin:0 0 10px;font-size:28px}p{line-height:1.7;color:#cde6f5}.badge{display:inline-block;padding:8px 12px;border-radius:999px;background:#73c8f0;color:#06202e;font-weight:900}</style></head><body><main class="card"><span class="badge">Pongdang4 v4.4.5</span><h1>GitHub 최신 기준본 저장 완료</h1><p>이 저장소는 퐁당-4 곤지암천 수중 생태 학습 프로젝트의 최신 기준 저장소입니다. 대용량 실행 HTML은 현재 작업 패키지 기준으로 관리하며, 다음 단계부터 GitHub 기준으로 계속 업데이트합니다.</p><p>다음 개발 순서: <b>v4.4.6 BackObjects 슬롯에 뒤쪽 수초 1개 적용</b></p></main></body></html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=./app_assets/index.html">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <title>퐁당4 v4.8.28 시연</title>
+</head>
+<body>
+  <!-- 한글 리마크: GitHub/Netlify 루트 주소로 접속하면 최신 앱 화면으로 바로 이동한다. -->
+  <p>최신 시연 화면으로 이동 중입니다. 자동 이동이 되지 않으면 <a href="./app_assets/index.html">여기</a>를 눌러 주세요.</p>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -2,35 +2,35 @@
   "project": "pongdang-v5-web",
   "repository": "tantarus71-ctrl/pongdang-v5-web",
   "branch": "main",
-  "version": "v4.5.5-doc-standard",
-  "status": "integrated development standard with camera VR GPS registered",
+  "version": "v4.8.28",
+  "status": "beodeulchi now swim with more realistic varied speeds while preserving smooth aquarium movement",
   "source_of_truth": "github + codex package",
   "entrypoints": {
     "root": "index.html",
-    "viewer": "00_열어서확인.html",
-    "app": "app_assets/index.html"
-  },
-  "latest_package": "pongdang4_v4_5_5_quality_stability_optimized.zip",
-  "latest_standard_doc": {
-    "markdown": "docs/PONGDANG_V5_AFTER_v4_5_5_INTEGRATED_STANDARD_CAMERA_VR_GPS.md",
-    "docx_local": "퐁당퐁당_V5_v4.5.5이후_통합개발기준서_카메라VRGPS포함.docx",
-    "pdf_local": "퐁당퐁당_V5_v4.5.5이후_통합개발기준서_카메라VRGPS포함.pdf"
+    "viewer": "viewer.html",
+    "app": "app_assets/index.html",
+    "patch": "patches/latest.generated.patch.js"
   },
   "rules": [
+    "Preserve aquarium frame structure",
+    "Patch elements only unless explicitly rebaselining",
     "Keep GitHub main as latest reference",
-    "Keep Codex and ChatGPT filenames identical",
-    "After v4.5.5, pause species expansion until mobile QA",
-    "Camera, GPS, and VR/cinema mode must be designed with permission fallback",
-    "Child safety and observation-first UX are required",
-    "Fish visual image must keep pointer-events none",
-    "Root entry must remain index.html and app entry must remain app_assets/index.html"
+    "Advance objects one slot at a time",
+    "Run structure validation before future releases",
+    "Do not merge auto patches directly to main without PR review"
   ],
+  "latest_package": "pongdang4_v4_8_28_realistic_varied_beodeulchi_speed.zip",
+  "final_background": {
+    "slot": "upper.day",
+    "file": "assets/backgrounds/upper_day_underwater_real_v2.png",
+    "description": "realistic underwater riverbed background with integrated rock depth layout"
+  },
   "completed_step": {
-    "version": "v4.5.5-doc-standard",
-    "task": "Registered integrated development standard including camera, VR/cinema, GPS, child psychology, Gonjiamcheon zones, and future nature expansion"
+    "version": "v4.8.28",
+    "task": "Increased per-fish speed variation and reduced overly slow cruise durations for more realistic beodeulchi motion"
   },
   "next_step": {
-    "version": "v4.5.6",
-    "task": "Mobile real-device QA package before camera/GPS/VR implementation"
+    "version": "v4.8.29",
+    "task": "Browser-observe beodeulchi motion and tune only small speed increments if any fish feels too fast"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pongdang-v5-web-autopatch-bridge",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "patch:generate": "node ./bridge/generate-patch.mjs",
+    "patch:generate:dry": "node ./bridge/generate-patch.mjs --dry-run",
+    "validate:structure": "node ./bridge/validate-structure.mjs",
+    "diagnose:stability": "node ./bridge/diagnose-stability.mjs"
+  }
+}

--- a/project-manifest.json
+++ b/project-manifest.json
@@ -1,0 +1,25 @@
+{
+  "version": "v4.8.28",
+  "title": "Realistic varied beodeulchi swim speeds",
+  "html": "app_assets/index.html",
+  "app_asset": "app_assets/index.html",
+  "auto_patch": "patches/latest.generated.patch.js",
+  "background": "assets/backgrounds/upper_day_underwater_real_v2.png",
+  "latest_package": "pongdang4_v4_8_28_realistic_varied_beodeulchi_speed.zip",
+  "final_background": {
+    "slot": "upper.day",
+    "file": "assets/backgrounds/upper_day_underwater_real_v2.png",
+    "description": "realistic underwater riverbed background with integrated rock depth layout"
+  },
+  "object_slots": {
+    "back": "aquariumBackObjectsV445",
+    "mid": "aquariumMidObjectsV445",
+    "front": "aquariumFrontObjectsV445"
+  },
+  "viewer": "viewer.html",
+  "completed_step": {
+    "version": "v4.8.28",
+    "task": "Increased per-fish speed variation and reduced overly slow cruise durations for more realistic beodeulchi motion"
+  },
+  "next_step": "v4.8.29 browser-observe beodeulchi motion and tune only small speed increments if any fish feels too fast"
+}

--- a/prompts/patch-system.md
+++ b/prompts/patch-system.md
@@ -1,0 +1,18 @@
+You are generating a browser runtime patch for the Pongdang app.
+
+Return JavaScript only.
+Do not return markdown fences.
+Do not explain anything.
+
+Hard constraints:
+- The patch must assign an object to `window.PONDANG_AUTO_PATCH`.
+- The patch must include an `apply()` function.
+- Preserve the aquarium frame and base structure.
+- Modify elements only: text, visual tuning, overlays, runtime hooks, light interactions, safe recalibration.
+- Do not replace the whole document.
+- Do not remove existing safety guards.
+- Keep the patch additive and idempotent.
+- Prefer DOM/CSS/runtime adjustments over structural rewrites.
+- Avoid external dependencies.
+
+The output must be a complete standalone patch file that can overwrite `patches/latest.generated.patch.js`.

--- a/prompts/patch-user-template.md
+++ b/prompts/patch-user-template.md
@@ -1,0 +1,24 @@
+Project context:
+{{PROJECT_CONTEXT}}
+
+User brief:
+{{USER_BRIEF}}
+
+Current patch file:
+{{CURRENT_PATCH}}
+
+Relevant base app tail snippet:
+{{BASE_APP_SNIPPET}}
+
+Task:
+Generate the next full contents of `patches/latest.generated.patch.js`.
+
+Requirements:
+- Keep `window.PONDANG_AUTO_PATCH` as the public entry.
+- Update patch id and version meaningfully if behavior changes.
+- Keep execution safe on repeated reloads.
+- Preserve existing frame/layout structure.
+- Patch only what is necessary for the user brief.
+- Always respect the current source-of-truth and file naming rules in the brief.
+- Do not treat compatibility alias files as canonical targets.
+- If the requested change belongs in metadata only, avoid changing runtime patch logic unnecessarily.


### PR DESCRIPTION
## Summary

- Promotes repository metadata from old GitHub baseline to local v4.8.28 status.
- Adds safe GitHub Actions workflow for OpenAI auto-patch generation through reviewed PRs instead of direct main pushes.
- Adds the bridge scripts, prompts, package scripts, OpenAI/GitHub connection guides, and validators needed by the workflow.
- Updates root index to redirect to the app entry.

## Safety

- This PR does not directly replace main without review.
- The current full runnable local package remains `pongdang-v4.8.28-netlify-demo.zip` / Netlify deployment.
- Large local runtime assets and full app HTML should be uploaded in a follow-up when a Git client or GitHub release asset workflow is available, because the GitHub connector is not ideal for bulk PNG/large HTML upload.

## Current local latest

- Local app version: v4.8.28
- Local package: pongdang-v4.8.28-netlify-demo.zip
- Current deploy folder: deploy_netlify_v4_8_28
- Netlify URL: https://pongdong-johnchoi.netlify.app/app_assets/index.html

## Validation run locally

- `node --check patches/latest.generated.patch.js`
- `node bridge/validate-structure.mjs`
- `node bridge/diagnose-stability.mjs`

## Review note

This is intentionally a Draft PR. Review the workflow and metadata first; upload the full runtime app/assets in a separate bulk-safe step if you want GitHub to become the full deploy source.